### PR TITLE
feat(dashboard): import proxies to custom clusters

### DIFF
--- a/dashboard/templates/dashboard/custom_clusters.html
+++ b/dashboard/templates/dashboard/custom_clusters.html
@@ -47,6 +47,9 @@
                 <button class="btn btn-primary w-100 mt-3" id="new-cluster-btn">
                     <i class="fas fa-plus"></i> Create Cluster from Search
                 </button>
+                <button class="btn btn-outline-primary w-100 mt-2" id="import-proxy-btn">
+                    <i class="fas fa-download"></i> Import from Proxy Run
+                </button>
             </div>
 
             <div class="custom-cluster-layout">
@@ -168,6 +171,84 @@
         </div>
     </div>
 </div>
+
+<!-- Import From Proxy Modal -->
+<div class="modal fade" id="proxy-import-modal" tabindex="-1" aria-labelledby="proxy-import-label" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="proxy-import-label">Import from Proxy Runs</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3 mb-2">
+                    <div class="col-md-3">
+                        <label class="form-label small mb-1">Run Type</label>
+                        <select class="form-select" id="import-run-type">
+                            <option value="">All</option>
+                            <option value="atoms">Atom Clustering</option>
+                            <option value="standards">Standard Clustering</option>
+                            <option value="topics">Topic Categorization</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-1">Grade Level</label>
+                        <select class="form-select" id="import-grade">
+                            <option value="">All Grades</option>
+                            {% for grade in grade_levels %}
+                            <option value="{{ grade.grade_numeric }}">{{ grade.grade }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-1">Subject Area</label>
+                        <select class="form-select" id="import-subject">
+                            <option value="">All Subjects</option>
+                            {% for subject in subject_areas %}
+                            <option value="{{ subject.id }}">{{ subject.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-1">Search</label>
+                        <input type="text" class="form-control" id="import-search" placeholder="Filter runs by name or notes">
+                    </div>
+                </div>
+                <div class="row g-3">
+                    <div class="col-md-5">
+                        <div class="border rounded p-2" style="max-height: 360px; overflow-y: auto;">
+                            <div class="d-flex align-items-center justify-content-between mb-2">
+                                <strong>Runs</strong>
+                                <button class="btn btn-sm btn-outline-secondary" id="refresh-runs-btn">Refresh</button>
+                            </div>
+                            <div id="import-runs-list" class="list-group small">
+                                <div class="text-muted">Loading…</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-7">
+                        <div class="border rounded p-2" style="max-height: 360px; overflow-y: auto;">
+                            <div class="d-flex align-items-center justify-content-between mb-2">
+                                <strong>Proxies in Selected Run</strong>
+                                <span class="text-muted small" id="selected-proxies-count">0 selected</span>
+                            </div>
+                            <div id="import-proxies-list" class="list-group small">
+                                <div class="text-muted">Select a run to view proxies…</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="confirm-import-proxies">
+                    <i class="fas fa-download"></i> Import Selected Proxies
+                </button>
+            </div>
+        </div>
+    </div>
+    
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -207,6 +288,9 @@
             reportsEndpoint: '{% url "dashboard:cluster_reports_api" %}',
             reportDetailBase: '{% url "dashboard:cluster_report_detail_api" "00000000-0000-0000-0000-000000000000" %}'.replace('00000000-0000-0000-0000-000000000000', ''),
             semanticSearchEndpoint: '{% url "dashboard:embeddings_semantic_search" %}',
+            proxyRunsListEndpoint: '{% url "dashboard:proxy_runs_list_api" %}',
+            proxyRunProxiesEndpoint: '{% url "dashboard:proxy_run_proxies_api" %}',
+            importProxiesEndpoint: '{% url "dashboard:import_proxies_as_clusters_api" %}',
             csrfToken: '{{ csrf_token }}'
         });
     });

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -10,6 +10,7 @@ from .views import (
     
     # Proxy API views
     proxy_run_coverage_api, proxy_run_proxies_api, generate_proxies_api,
+    proxy_runs_list_api,
     proxy_job_status_api, generate_standard_proxies_api, standard_proxy_job_status_api,
     proxy_detail_api,
     
@@ -29,6 +30,7 @@ from .views import (
 
     # Custom cluster APIs
     custom_clusters_api, custom_cluster_detail_api,
+    import_proxies_as_clusters_api,
     cluster_reports_api, cluster_report_detail_api,
 )
 
@@ -51,6 +53,7 @@ urlpatterns = [
     path('api/analyze-coverage/', analyze_coverage_api, name='analyze_coverage_api'),
     path('api/proxy-run-coverage/', proxy_run_coverage_api, name='proxy_run_coverage_api'),
     path('api/proxy-run-proxies/', proxy_run_proxies_api, name='proxy_run_proxies_api'),
+    path('api/proxy-runs/', proxy_runs_list_api, name='proxy_runs_list_api'),
     
     # Atom-level proxy endpoints
     path('api/generate-proxies/', generate_proxies_api, name='generate_proxies_api'),
@@ -95,6 +98,7 @@ urlpatterns = [
     # Custom cluster APIs
     path('api/custom-clusters/', custom_clusters_api, name='custom_clusters_api'),
     path('api/custom-clusters/<uuid:cluster_id>/', custom_cluster_detail_api, name='custom_cluster_detail_api'),
+    path('api/custom-clusters/import-from-proxies/', import_proxies_as_clusters_api, name='import_proxies_as_clusters_api'),
     path('api/cluster-reports/', cluster_reports_api, name='cluster_reports_api'),
     path('api/cluster-reports/<uuid:report_id>/', cluster_report_detail_api, name='cluster_report_detail_api'),
 ]

--- a/dashboard/views/__init__.py
+++ b/dashboard/views/__init__.py
@@ -15,6 +15,7 @@ from .dashboard_views import (
 from .proxy_api_views import (
     proxy_run_coverage_api,
     proxy_run_proxies_api,
+    proxy_runs_list_api,
     generate_proxies_api,
     proxy_job_status_api,
     generate_standard_proxies_api,
@@ -47,6 +48,7 @@ from .custom_cluster_api_views import (
     custom_cluster_detail_api,
     cluster_reports_api,
     cluster_report_detail_api,
+    import_proxies_as_clusters_api,
 )
 
 from .atomization_api_views import (
@@ -72,6 +74,7 @@ __all__ = [
     # Proxy API views
     'proxy_run_coverage_api',
     'proxy_run_proxies_api',
+    'proxy_runs_list_api',
     'generate_proxies_api',
     'proxy_job_status_api',
     'generate_standard_proxies_api',
@@ -99,6 +102,7 @@ __all__ = [
     # Custom cluster APIs
     'custom_clusters_api',
     'custom_cluster_detail_api',
+    'import_proxies_as_clusters_api',
     'cluster_reports_api',
     'cluster_report_detail_api',
 

--- a/standards/migrations/0017_add_topiccluster_source_fields.py
+++ b/standards/migrations/0017_add_topiccluster_source_fields.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('standards', '0016_clusterreport_clusterreportentry_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topiccluster',
+            name='source_proxy_id',
+            field=models.CharField(blank=True, help_text='ID of the originating proxy (proxy_id)', max_length=100),
+        ),
+        migrations.AddField(
+            model_name='topiccluster',
+            name='source_proxy_type',
+            field=models.CharField(blank=True, choices=[('topics', 'Topic-Based Proxy'), ('atoms', 'Atom Clustering Proxy'), ('standards', 'Standard Clustering Proxy')], help_text='Type of the originating proxy', max_length=20),
+        ),
+        migrations.AddField(
+            model_name='topiccluster',
+            name='source_run',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='derived_clusters', to='standards.proxyrun'),
+        ),
+        migrations.AddField(
+            model_name='topiccluster',
+            name='source_title',
+            field=models.CharField(blank=True, help_text='Snapshot of originating proxy title at time of import', max_length=255),
+        ),
+        migrations.AddIndex(
+            model_name='topiccluster',
+            index=models.Index(fields=['source_proxy_type', 'source_proxy_id'], name='standards_to_source__2c8be9_idx'),
+        ),
+    ]
+

--- a/tests/test_import_proxies_to_clusters.py
+++ b/tests/test_import_proxies_to_clusters.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""
+Tests for importing proxies as editable custom clusters.
+"""
+import os
+import django
+
+# Set up Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'state_standards_project.settings')
+django.setup()
+
+from django.test import Client
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from standards.models import State, SubjectArea, GradeLevel, Standard, TopicBasedProxy, ProxyRun, TopicCluster
+import json
+
+
+def ensure_admin_user():
+    User = get_user_model()
+    admin_user, created = User.objects.get_or_create(
+        username='admin',
+        defaults={'is_staff': True, 'is_superuser': True, 'email': 'admin@example.com'}
+    )
+    if created:
+        admin_user.set_password('admin123')
+        admin_user.save()
+    return admin_user
+
+
+def create_minimal_standard(state, subject, grades, code_suffix):
+    std = Standard.objects.create(
+        state=state,
+        subject_area=subject,
+        code=f"{state.code}.{code_suffix}",
+        title=f"Standard {code_suffix}",
+        description=f"Desc {code_suffix}",
+        domain="Test",
+        cluster="Test",
+    )
+    std.grade_levels.set(list(GradeLevel.objects.filter(grade_numeric__in=grades)))
+    return std
+
+
+def test_import_topic_based_proxy_as_cluster():
+    print("🧪 Testing import from topic-based proxy...")
+    admin = ensure_admin_user()
+    client = Client()
+    client.force_login(admin)
+
+    # Setup minimal taxonomy
+    ca, _ = State.objects.get_or_create(code='CA', defaults={'name': 'California'})
+    tx, _ = State.objects.get_or_create(code='TX', defaults={'name': 'Texas'})
+    math, _ = SubjectArea.objects.get_or_create(name='Mathematics')
+    for g in range(0, 3):
+        GradeLevel.objects.get_or_create(grade=str(g if g > 0 else 'K'), defaults={'grade_numeric': g})
+
+    # Create standards
+    s1 = create_minimal_standard(ca, math, [0, 1], 'MATH.1.A')
+    s2 = create_minimal_standard(tx, math, [1], 'MATH.1.B')
+
+    # Topic-based proxy with member standards
+    tproxy = TopicBasedProxy.objects.create(
+        proxy_id='TP-TEST-001',
+        topic='Numbers',
+        sub_topic='Counting',
+        sub_sub_topic='Basic',
+        title='Counting Basics',
+        description='Counting basics proxy'
+    )
+    tproxy.member_standards.add(s1, s2)
+    tproxy.save()
+
+    # Proxy run
+    run = ProxyRun.objects.create(
+        run_id='topics-test-run-1',
+        name='Topic Run 1',
+        run_type='topics',
+        status='completed',
+        filter_parameters={'subject_area_id': math.id, 'grade_selection': {'type': 'specific', 'grades': [0, 1]}},
+        started_at=timezone.now(),
+        completed_at=timezone.now(),
+    )
+
+    payload = {
+        'imports': [
+            { 'run_id': run.run_id, 'proxy_type': 'topics', 'proxy_id': tproxy.proxy_id }
+        ]
+    }
+    url = '/dashboard/api/custom-clusters/import-from-proxies/'
+    resp = client.post(url, data=json.dumps(payload), content_type='application/json')
+    assert resp.status_code in (200, 201), f"Unexpected status: {resp.status_code} {resp.content}"
+    data = resp.json().get('data', {})
+    created = data.get('created', [])
+    assert created, 'No cluster created'
+    cluster = created[0]
+    assert cluster.get('origin') == 'custom'
+    assert cluster.get('copied_from_proxy') is True
+    assert cluster.get('source', {}).get('run_id') == run.run_id
+    assert cluster.get('source', {}).get('proxy_id') == tproxy.proxy_id
+    members = cluster.get('members', [])
+    assert len(members) == 2, 'Imported cluster should have 2 members'
+
+    # Ensure cluster exists in DB with source metadata
+    db_cluster = TopicCluster.objects.get(id=cluster['id'])
+    assert db_cluster.source_run_id == run.id
+    assert db_cluster.source_proxy_id == tproxy.proxy_id
+    assert db_cluster.source_proxy_type == 'topics'
+    assert db_cluster.standards.count() == 2
+
+    print('✅ Import topic-based proxy passed')
+


### PR DESCRIPTION
…ters

- Added a modal for importing proxies from completed proxy runs, allowing users to filter and select proxies for import.
- Introduced new API endpoints to list completed proxy runs and import selected proxies as custom clusters.
- Enhanced the custom clusters template and JavaScript to support the new import feature, including state management for selected proxies.
- Updated the TopicCluster model to store metadata about the source of imported proxies, improving traceability and management of imported clusters.